### PR TITLE
fix: prevent history from reset on load

### DIFF
--- a/.changeset/short-trees-rhyme.md
+++ b/.changeset/short-trees-rhyme.md
@@ -1,0 +1,5 @@
+---
+'gungi.js': patch
+---
+
+prevent history for resetting when calling load(fen)

--- a/src/gungi/gungi.ts
+++ b/src/gungi/gungi.ts
@@ -233,7 +233,6 @@ export class Gungi {
 
 	load(fen: string) {
 		this.#initializeState(parseFEN(fen));
-		this.#history = [];
 	}
 
 	loadPgn(


### PR DESCRIPTION
Before, we cleared the game history whenever we called the `load(fen)` function. now we just update the board position and keep previous history