### PR TITLE
fix: load pgn bug

### DIFF
--- a/.changeset/silent-beers-flash.md
+++ b/.changeset/silent-beers-flash.md
@@ -1,0 +1,5 @@
+---
+'gungi.js': patch
+---
+
+load pgn was not filtering out empty moves when parsing pgn

--- a/src/gungi/pgn.ts
+++ b/src/gungi/pgn.ts
@@ -60,9 +60,12 @@ export function encodePGN(history: Move[], opts?: PGNOptions) {
 
 export function parsePGN(pgn: string, opts?: Pick<PGNOptions, 'newline'>) {
 	const newline = opts?.newline ?? '\n';
-	const moves = pgn.split(newline).flatMap((line) => {
-		return line.replace(/\d+\.+/g, '').split(' ');
-	});
+	const moves = pgn
+		.split(newline)
+		.flatMap((line) => {
+			return line.replace(/\d+\.+/g, '').split(' ');
+		})
+		.filter((move) => move !== '');
 
 	return moves;
 }


### PR DESCRIPTION
when parsing pgn to load it into the game state we were not filtering out empty strings when splitting moves