### PR TITLE
fix: marshal stacking allowed for diff game modes

### DIFF
--- a/.changeset/olive-comics-build.md
+++ b/.changeset/olive-comics-build.md
@@ -1,0 +1,5 @@
+---
+'gungi.js': patch
+---
+
+Marshals should not be able to stack in intro and beginner game modes

--- a/src/gungi/move_gen.ts
+++ b/src/gungi/move_gen.ts
@@ -129,13 +129,16 @@ export function generateMovesForSquare(square: string, fen: string) {
 		const t = get(s, board);
 
 		const maxTier = mode === 'advanced' ? 3 : 2;
+		const marshalCanStack = ['advanced', 'intermediate'].includes(mode);
 
 		if (!p || !t) {
 			acc.push(createMove(piece, `${s}-1`, fen, 'route'));
 		} else {
 			// tsuke
 			if (p.tier < maxTier && p.type !== pieceType.marshal) {
-				acc.push(createMove(piece, `${s}-${p.tier + 1}`, fen, 'tsuke'));
+				if (piece.type !== pieceType.marshal || marshalCanStack) {
+					acc.push(createMove(piece, `${s}-${p.tier + 1}`, fen, 'tsuke'));
+				}
 
 				// betrayal
 				if (piece.type === pieceType.tactician && p.color !== piece.color) {


### PR DESCRIPTION
📚 marshals should not be able to stack in intro and beginner game modes, but can in intermediate and advanced