### PR TITLE
feat: 👤 add persistent piece ID tracking system

### DIFF
--- a/.changeset/four-pears-sneeze.md
+++ b/.changeset/four-pears-sneeze.md
@@ -1,0 +1,30 @@
+---
+'gungi.js': minor
+---
+
+Implements unique piece identifiers using `type-color-number` format
+that persist across all moves, captures, and state changes.
+
+**Parallel ID Registry**: Chose to maintain existing FEN-based
+architecture while adding separate `PieceIdRegistry` class. This
+preserves backward compatibility while enabling advanced ID features.
+
+**Snapshot/Restore Pattern**: Since moves regenerate state from FEN
+(losing IDs), implemented snapshot-before/restore-after pattern in
+`move()` method. Captures ID mappings before FEN reinitialization,
+then intelligently restores them accounting for piece movements.
+
+**Individual Hand Tracking**: Extended `HandPiece` with `ids?: string[]`
+to track individual pieces within aggregate counts. Enables specific
+piece selection for arata moves while maintaining existing count-based API.
+
+**Auto-Assignment**: IDs assigned automatically on game initialization.
+All existing code works unchanged, IDs are purely additive enhancement.
+
+- `getPieceId()`, `getPieceById()` - board piece lookup
+- `getHandPieceIds()`, `getHandWithIds()` - hand piece access
+- `getBoardWithIds()` - complete board state with IDs
+- `getHandPieceId()` - specific hand piece selection
+
+Addresses the fundamental challenge of maintaining piece identity
+across the library's FEN-based state management system.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ gungi.js is a TypeScript gungi library for the strategy game from the HUNTER×HU
 Credit to these two reddit posts from [u/magickirua](https://www.reddit.com/r/HunterXHunter/comments/uqrtct/gungi_the_official_rules) and [u/MythicalTenshi](https://www.reddit.com/r/HunterXHunter/comments/105f43g/comment/j3evkkq)
 which translate the rule book.
 
-gungi.js is used for move generation/validation, piece placement/movement, and endgame detection - basically everything but the AI.
+gungi.js is used for move generation/validation, piece placement/movement, piece ID tracking, and endgame detection - basically everything but the AI.
 
 ## Installation
 
@@ -299,6 +299,19 @@ gungi.getDraftingRights('b');
 // -> true
 ```
 
+### .getBoardWithIds()
+
+Returns a copy of the 3D board tensor with all piece ID information included. Each piece object includes an `id` field with its unique identifier.
+
+```ts
+const gungi = new Gungi(BEGINNER_POSITION);
+const boardWithIds = gungi.getBoardWithIds();
+
+// Access piece with ID
+const piece = boardWithIds[6][0][0]; // 7-1 square
+// -> { square: '7-1', tier: 1, type: '兵', color: 'w', id: '兵-w-1' }
+```
+
 ### .getTop(square)
 
 Returns the top piece of the tower on the square. Returns `undefined` if the square is empty.
@@ -309,6 +322,89 @@ const gungi = new Gungi(BEGINNER_POSITION);
 gungi.get('7-4');
 // -> [{ square: '7-4', tier: 1, type: '侍', color: 'w' }]
 gungi.get('7-3');
+// -> undefined
+```
+
+### .getHandPieceId(type, color, index)
+
+Returns the ID of a specific hand piece by type, color, and index. Useful for selecting which specific piece to play when multiple pieces of the same type are in hand.
+
+```ts
+const gungi = new Gungi(BEGINNER_POSITION);
+
+// Get ID of first major general in white's hand
+const firstId = gungi.getHandPieceId('小', 'w', 0);
+// -> '小-w-1'
+
+// Get ID of second major general (if exists)
+const secondId = gungi.getHandPieceId('小', 'w', 1);
+// -> '小-w-2' or undefined if only one exists
+```
+
+### .getHandPieceIds(type?, color?)
+
+Returns an array of all hand piece IDs. Can optionally filter by piece type and color.
+
+```ts
+const gungi = new Gungi(BEGINNER_POSITION);
+
+// Get all white major general IDs
+const whiteGeneralIds = gungi.getHandPieceIds('小', 'w');
+// -> ['小-w-1', '小-w-2']
+
+// Get all hand piece IDs
+const allHandIds = gungi.getHandPieceIds();
+// -> ['小-w-1', '小-w-2', '槍-w-1', ..., '小-b-1', '小-b-2', ...]
+```
+
+### .getHandWithIds(color?)
+
+Returns hand pieces with individual ID arrays included. Similar to `.hand()` but includes the `ids` field for each hand piece.
+
+```ts
+const gungi = new Gungi(BEGINNER_POSITION);
+
+const whiteHandWithIds = gungi.getHandWithIds('w');
+// -> [
+//      { type: '小', count: 2, color: 'w', ids: ['小-w-1', '小-w-2'] },
+//      { type: '槍', count: 3, color: 'w', ids: ['槍-w-1', '槍-w-2', '槍-w-3'] },
+//      ...
+//    ]
+```
+
+### .getPieceById(id)
+
+Returns the piece object with the specified ID. Searches the entire board to find the piece.
+
+```ts
+const gungi = new Gungi(BEGINNER_POSITION);
+
+// Find piece by its unique ID
+const piece = gungi.getPieceById('兵-w-1');
+// -> { square: '7-1', tier: 1, type: '兵', color: 'w', id: '兵-w-1' }
+
+// Returns undefined if piece doesn't exist or was captured
+const nonexistent = gungi.getPieceById('兵-w-999');
+// -> undefined
+```
+
+### .getPieceId(square, tier?)
+
+Returns the unique ID of the piece at the specified location. If tier is omitted, returns the ID of the top piece.
+
+```ts
+const gungi = new Gungi(BEGINNER_POSITION);
+
+// Get ID of top piece at square
+const topPieceId = gungi.getPieceId('7-1');
+// -> '兵-w-1'
+
+// Get ID of piece at specific tier
+const specificTierId = gungi.getPieceId('7-4', 2); // After stacking
+// -> '砦-w-1'
+
+// Returns undefined if no piece at location
+const emptyId = gungi.getPieceId('5-5');
 // -> undefined
 ```
 

--- a/src/gungi/gungi.ts
+++ b/src/gungi/gungi.ts
@@ -34,6 +34,8 @@ import {
 	MARSHAL,
 	Move,
 	MUSKETEER,
+	Piece,
+	PieceIdRegistry,
 	pieceToFenCode,
 	RIDER,
 	SetupMode,
@@ -89,6 +91,7 @@ export class Gungi {
 	#mode!: SetupMode;
 
 	#history: Move[] = [];
+	#idRegistry: PieceIdRegistry;
 
 	#initPosition: string;
 
@@ -106,10 +109,76 @@ export class Gungi {
 		this.#moveNumber = moveNumber;
 		this.#drafting = drafting;
 		this.#mode = mode;
+
+		// Assign IDs to pieces that don't have them and sync registry
+		this.#assignMissingIds();
+		this.#syncRegistryWithState();
+	}
+
+	#assignMissingIds() {
+		// Assign IDs to board pieces without them
+		for (let rank = 0; rank < 9; rank++) {
+			for (let file = 0; file < 9; file++) {
+				const tower = this.#board[rank][file];
+				if (tower && tower[0]) {
+					for (let tierIdx = 0; tierIdx < tower.length; tierIdx++) {
+						const piece = tower[tierIdx];
+						if (piece && !piece.id) {
+							piece.id = this.#idRegistry.createPieceWithId(
+								piece.type,
+								piece.color,
+								piece.square,
+								piece.tier
+							).id;
+						}
+					}
+				}
+			}
+		}
+
+		// Assign IDs to hand pieces without them
+		for (const handPiece of this.#hand) {
+			if (!handPiece.ids || handPiece.ids.length === 0) {
+				handPiece.ids = [];
+				for (let i = 0; i < handPiece.count; i++) {
+					const newId = this.#idRegistry.createPieceWithId(
+						handPiece.type,
+						handPiece.color,
+						'hand',
+						0
+					).id!;
+					handPiece.ids.push(newId);
+					// Remove from board registry since it's in hand
+					this.#idRegistry.removePieceId('hand', 0);
+					// Add to hand registry
+					this.#idRegistry.addToHand(handPiece.type, handPiece.color, [newId]);
+				}
+			} else {
+				// Ensure hand registry is synced
+				const existingIds = this.#idRegistry.getHandIds(
+					handPiece.type,
+					handPiece.color
+				);
+				if (existingIds.length !== handPiece.count) {
+					// Clear and rebuild hand registry for this piece type/color
+					const key = `${handPiece.type}-${handPiece.color}`;
+					this.#idRegistry.addToHand(
+						handPiece.type,
+						handPiece.color,
+						handPiece.ids.slice()
+					);
+				}
+			}
+		}
+	}
+
+	#syncRegistryWithState() {
+		this.#idRegistry.syncWithBoard(this.#board, this.#hand);
 	}
 
 	constructor(fen?: string) {
 		this.#initPosition = fen ?? INTRO_POSITION;
+		this.#idRegistry = new PieceIdRegistry();
 		this.#initializeState(parseFEN(this.#initPosition));
 	}
 
@@ -262,10 +331,191 @@ export class Gungi {
 					);
 		if (!found) throw new Error(`Illegal move: ${move}`);
 
+		// Capture ID information before move execution
+		const idSnapshot = this.#captureIdSnapshot(found);
+
 		this.#history.push(found);
 		if (this.isFourfoldRepetition()) this.#history.at(-1)!.san += '停';
+
+		// Initialize new state from FEN (this loses IDs)
 		this.#initializeState(parseFEN(found.after));
+
+		// Restore ID mappings accounting for the move
+		this.#restoreIdMappings(found, idSnapshot);
+
 		return found;
+	}
+
+	#captureIdSnapshot(move: Move) {
+		const snapshot = {
+			boardPieces: new Map<string, string>(), // square-tier -> ID
+			handPieces: new Map<string, string[]>(), // type-color -> IDs
+			movingPieceId: null as string | null,
+			capturedIds: [] as string[],
+			handPieceId: null as string | null, // for arata moves
+		};
+
+		// Capture all board pieces
+		for (let rank = 0; rank < 9; rank++) {
+			for (let file = 0; file < 9; file++) {
+				const tower = this.#board[rank][file];
+				if (tower && tower[0]) {
+					for (const piece of tower) {
+						if (piece && piece.id) {
+							snapshot.boardPieces.set(
+								`${piece.square}-${piece.tier}`,
+								piece.id
+							);
+						}
+					}
+				}
+			}
+		}
+
+		// Capture hand pieces
+		for (const handPiece of this.#hand) {
+			if (handPiece.ids && handPiece.ids.length > 0) {
+				snapshot.handPieces.set(`${handPiece.type}-${handPiece.color}`, [
+					...handPiece.ids,
+				]);
+			}
+		}
+
+		// Capture moving piece ID
+		if (move.from) {
+			const movingPiece = this.getTop(move.from);
+			if (movingPiece && movingPiece.id) {
+				snapshot.movingPieceId = movingPiece.id;
+			}
+		}
+
+		// For arata moves, capture the hand piece ID being used
+		if (move.type === 'arata') {
+			const handPieces = this.#hand.find(
+				(hp) => hp.type === move.piece && hp.color === move.color
+			);
+			if (handPieces && handPieces.ids && handPieces.ids.length > 0) {
+				snapshot.handPieceId = handPieces.ids[0]; // Use first available
+			}
+		}
+
+		// Capture IDs of pieces being captured
+		if (move.captured) {
+			snapshot.capturedIds = move.captured
+				.map((p) => p.id)
+				.filter((id): id is string => id !== undefined);
+		}
+
+		return snapshot;
+	}
+
+	#restoreIdMappings(move: Move, snapshot: any) {
+		// Clear current registry and rebuild with ID preservation
+		this.#idRegistry = new PieceIdRegistry();
+
+		// Restore board pieces, accounting for the move
+		const [toRank, toFile, toTier] = move.to.split('-').map(Number);
+
+		for (let rank = 0; rank < 9; rank++) {
+			for (let file = 0; file < 9; file++) {
+				const tower = this.#board[rank][file];
+				if (tower && tower[0]) {
+					for (let tierIdx = 0; tierIdx < tower.length; tierIdx++) {
+						const piece = tower[tierIdx];
+						if (piece) {
+							let pieceId: string;
+
+							// Check if this is the destination of our move
+							if (
+								rank === toRank - 1 &&
+								file === 9 - toFile &&
+								tierIdx === toTier - 1
+							) {
+								// This is the piece that moved
+								if (move.type === 'arata' && snapshot.handPieceId) {
+									pieceId = snapshot.handPieceId;
+								} else if (snapshot.movingPieceId) {
+									pieceId = snapshot.movingPieceId;
+								} else {
+									// Generate new ID if we can't find the original
+									pieceId = this.#idRegistry.createPieceWithId(
+										piece.type,
+										piece.color,
+										piece.square,
+										piece.tier
+									).id!;
+								}
+							} else {
+								// Try to find existing ID for this position
+								const existingId = snapshot.boardPieces.get(
+									`${piece.square}-${piece.tier}`
+								);
+								if (existingId) {
+									pieceId = existingId;
+								} else {
+									// Generate new ID
+									pieceId = this.#idRegistry.createPieceWithId(
+										piece.type,
+										piece.color,
+										piece.square,
+										piece.tier
+									).id!;
+								}
+							}
+
+							piece.id = pieceId;
+							this.#idRegistry.setPieceId(piece.square, piece.tier, pieceId);
+						}
+					}
+				}
+			}
+		}
+
+		// Restore hand pieces with proper ID tracking
+		for (const handPiece of this.#hand) {
+			const key = `${handPiece.type}-${handPiece.color}`;
+			let ids = snapshot.handPieces.get(key) || [];
+
+			// Handle captured pieces being added to hand
+			if (move.captured && move.type === 'capture') {
+				const capturedOfThisType = move.captured.filter(
+					(p) =>
+						p.type === handPiece.type &&
+						(p.color === 'w' ? 'b' : 'w') === handPiece.color
+				);
+				for (const captured of capturedOfThisType) {
+					if (captured.id) {
+						ids.push(captured.id);
+					}
+				}
+			}
+
+			// For arata moves, remove the used piece ID
+			if (
+				move.type === 'arata' &&
+				move.piece === handPiece.type &&
+				move.color === handPiece.color &&
+				snapshot.handPieceId
+			) {
+				ids = ids.filter((id: string) => id !== snapshot.handPieceId);
+			}
+
+			// Ensure we have the right number of IDs
+			while (ids.length < handPiece.count) {
+				const newId = this.#idRegistry.createPieceWithId(
+					handPiece.type,
+					handPiece.color,
+					'hand',
+					0
+				).id!;
+				this.#idRegistry.removePieceId('hand', 0);
+				ids.push(newId);
+			}
+
+			ids = ids.slice(0, handPiece.count);
+			handPiece.ids = ids;
+			this.#idRegistry.addToHand(handPiece.type, handPiece.color, ids);
+		}
 	}
 
 	moves(opts?: { square?: string; arata?: HandPiece; verbose?: boolean }) {
@@ -327,5 +577,104 @@ export class Gungi {
 
 	validateFen(fen: string) {
 		return validateFen(fen);
+	}
+
+	// ID-aware methods
+	getPieceId(square: string, tier?: number): string | undefined {
+		if (tier !== undefined) {
+			return this.#idRegistry.getPieceId(square, tier);
+		}
+
+		// Get ID of top piece if tier not specified
+		const topPiece = this.getTop(square);
+		if (topPiece) {
+			return this.#idRegistry.getPieceId(square, topPiece.tier);
+		}
+
+		return undefined;
+	}
+
+	getPieceById(id: string): Piece | undefined {
+		// Search board for piece with this ID
+		for (let rank = 0; rank < 9; rank++) {
+			for (let file = 0; file < 9; file++) {
+				const tower = this.#board[rank][file];
+				if (tower && tower[0]) {
+					for (const piece of tower) {
+						if (piece && piece.id === id) {
+							return piece;
+						}
+					}
+				}
+			}
+		}
+		return undefined;
+	}
+
+	getHandPieceIds(type?: string, color?: Color): string[] {
+		if (type && color) {
+			return this.#idRegistry.getHandIds(type as any, color);
+		}
+
+		// Get all hand piece IDs
+		const allIds: string[] = [];
+		for (const handPiece of this.#hand) {
+			if (handPiece.ids) {
+				allIds.push(...handPiece.ids);
+			}
+		}
+		return allIds;
+	}
+
+	getBoardWithIds(): (Piece | null)[][][] {
+		// Return a copy of the board with all ID information
+		return this.#board.map((rank) =>
+			rank.map((tower) => tower.map((piece) => (piece ? { ...piece } : null)))
+		);
+	}
+
+	getHandWithIds(color?: Color): HandPiece[] {
+		// Return hand pieces with ID arrays
+		const handWithIds = this.#hand.map((hp) => ({ ...hp }));
+		return color
+			? handWithIds.filter((piece) => piece.color === color)
+			: handWithIds;
+	}
+
+	// Get a specific hand piece ID (useful for selecting which piece to play)
+	getHandPieceId(
+		type: string,
+		color: Color,
+		index: number = 0
+	): string | undefined {
+		const handPiece = this.#hand.find(
+			(hp) => hp.type === type && hp.color === color
+		);
+		if (handPiece && handPiece.ids && handPiece.ids.length > index) {
+			return handPiece.ids[index];
+		}
+		return undefined;
+	}
+
+	// Remove a specific hand piece ID (useful for implementing piece selection)
+	removeHandPieceId(type: string, color: Color, id: string): boolean {
+		const handPiece = this.#hand.find(
+			(hp) => hp.type === type && hp.color === color
+		);
+		if (handPiece && handPiece.ids) {
+			const index = handPiece.ids.indexOf(id);
+			if (index !== -1) {
+				handPiece.ids.splice(index, 1);
+				handPiece.count = Math.max(0, handPiece.count - 1);
+				this.#idRegistry.removeFromHand(type as any, color, 1);
+				return true;
+			}
+		}
+		return false;
+	}
+
+	// Debug method to inspect registry state
+	getIdRegistryState() {
+		return this.#idRegistry.getRegistryState();
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
-// import { ADVANCED_POSITION, Gungi } from './gungi';
-
 export * from './gungi';
 
+// Uncomment the code below to run an interactive demo showing piece ID tracking in action:
+
+// import { ADVANCED_POSITION, Gungi } from './gungi';
+//
 // function clearTerminal() {
 // 	process.stdout.write('\x1b[2J');
 // 	process.stdout.write('\x1b[H');
@@ -12,14 +14,130 @@ export * from './gungi';
 // 	process.stdout.write(text);
 // }
 //
-// const gungi = new Gungi(ADVANCED_POSITION);
-//
-// while (!gungi.isGameOver()) {
-// 	const moves = gungi.moves();
-// 	const move = moves[Math.floor(Math.random() * moves.length)];
-// 	gungi.move(move);
-// 	printText(gungi.ascii());
+// function waitForEnter(): Promise<void> {
+// 	return new Promise(resolve => {
+// 		process.stdin.setRawMode(true);
+// 		process.stdin.resume();
+// 		process.stdin.once('data', (data) => {
+// 			const input = data.toString();
+// 			if (input === '\r' || input === '\n' || input === '\x0D') {
+// 				process.stdin.setRawMode(false);
+// 				process.stdin.pause();
+// 				resolve();
+// 			} else {
+// 				// If not enter, wait again
+// 				process.stdin.setRawMode(false);
+// 				process.stdin.pause();
+// 				waitForEnter().then(resolve);
+// 			}
+// 		});
+// 	});
 // }
 //
-// console.log(gungi.fen() + '\n');
-// console.log(gungi.pgn());
+// function printIdInfo(gungi: Gungi, move: string) {
+// 	console.log(`\n=== Move: ${move} ===`);
+//
+// 	// Get all pieces on board
+// 	const boardPieces: Array<{square: string, piece: string, id: string}> = [];
+// 	for (let rank = 1; rank <= 9; rank++) {
+// 		for (let file = 1; file <= 9; file++) {
+// 			const piece = gungi.getTop(`${rank}-${file}`);
+// 			if (piece && piece.id) {
+// 				boardPieces.push({
+// 					square: piece.square,
+// 					piece: `${piece.type}${piece.color}`,
+// 					id: piece.id
+// 				});
+// 			}
+// 		}
+// 	}
+//
+// 	// Print board pieces in compact columns
+// 	console.log('Board IDs:');
+// 	if (boardPieces.length === 0) {
+// 		console.log('  (no pieces on board)');
+// 	} else {
+// 		// Split into 3 columns for better screen fit
+// 		const cols = 3;
+// 		const itemsPerCol = Math.ceil(boardPieces.length / cols);
+//
+// 		for (let i = 0; i < itemsPerCol; i++) {
+// 			let line = '';
+// 			for (let col = 0; col < cols; col++) {
+// 				const idx = col * itemsPerCol + i;
+// 				if (idx < boardPieces.length) {
+// 					const item = boardPieces[idx];
+// 					const entry = `${item.square}:${item.piece}=${item.id.split('-').pop()}`;
+// 					line += entry.padEnd(18);
+// 				}
+// 			}
+// 			console.log('  ' + line.trim());
+// 		}
+// 	}
+//
+// 	// Show hand piece IDs compactly
+// 	const whiteHand = gungi.getHandWithIds('w');
+// 	const blackHand = gungi.getHandWithIds('b');
+//
+// 	console.log('White Hand:');
+// 	if (whiteHand.length === 0) {
+// 		console.log('  (empty)');
+// 	} else {
+// 		const whiteEntries = whiteHand
+// 			.filter(hp => hp.count > 0)
+// 			.map(hp => `${hp.type}(${hp.count}):[${(hp.ids || []).map(id => id.split('-').pop()).join(',')}]`)
+// 			.join('  ');
+// 		console.log('  ' + whiteEntries);
+// 	}
+//
+// 	console.log('Black Hand:');
+// 	if (blackHand.length === 0) {
+// 		console.log('  (empty)');
+// 	} else {
+// 		const blackEntries = blackHand
+// 			.filter(hp => hp.count > 0)
+// 			.map(hp => `${hp.type}(${hp.count}):[${(hp.ids || []).map(id => id.split('-').pop()).join(',')}]`)
+// 			.join('  ');
+// 		console.log('  ' + blackEntries);
+// 	}
+//
+// 	console.log(`\nTurn: ${gungi.turn()}, Move #: ${gungi.moveNumber()}`);
+// 	console.log('='.repeat(70));
+// 	console.log('Press ENTER to continue...');
+// }
+//
+// async function playGame() {
+// 	const gungi = new Gungi(ADVANCED_POSITION);
+// 	let moveCount = 0;
+//
+// 	console.log('Starting random Gungi game with ID tracking...\n');
+//
+// 	while (!gungi.isGameOver() && moveCount < 500) { // Limit moves to prevent infinite games
+// 		const moves = gungi.moves();
+// 		const move = moves[Math.floor(Math.random() * moves.length)];
+//
+// 		const moveResult = gungi.move(move);
+// 		moveCount++;
+//
+// 		printText(gungi.ascii());
+// 		printIdInfo(gungi, moveResult.san); // Use the SAN from the move result
+//
+// 		// Wait for user to press Enter
+// 		await waitForEnter();
+// 	}
+//
+// 	console.log('\n' + '='.repeat(50));
+// 	console.log('GAME OVER!');
+// 	console.log('Final FEN: ' + gungi.fen());
+// 	console.log('\nGame PGN:');
+// 	console.log(gungi.pgn());
+//
+// 	// Show final registry state
+// 	console.log('\nFinal ID Registry State:');
+// 	const registryState = gungi.getIdRegistryState();
+// 	console.log('Total pieces tracked:', registryState.pieceIdMap.size);
+// 	console.log('Total hand pieces:', Array.from(registryState.handIdMap.values()).reduce((sum, ids) => sum + ids.length, 0));
+// }
+//
+// // Run the game
+// playGame().catch(console.error);

--- a/test/id-tracking.test.ts
+++ b/test/id-tracking.test.ts
@@ -1,0 +1,248 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { BEGINNER_POSITION, Gungi, INTRO_POSITION } from '../src/gungi';
+
+describe('ID Tracking', () => {
+	let gungi: Gungi;
+
+	beforeEach(() => {
+		gungi = new Gungi(INTRO_POSITION);
+	});
+
+	it('pieces should have IDs assigned on initialization', () => {
+		const board = gungi.getBoardWithIds();
+
+		// Check that board pieces have IDs
+		let pieceCount = 0;
+		let piecesWithIds = 0;
+
+		for (let rank = 0; rank < 9; rank++) {
+			for (let file = 0; file < 9; file++) {
+				const tower = board[rank][file];
+				if (tower && tower[0]) {
+					for (const piece of tower) {
+						if (piece) {
+							pieceCount++;
+							if (piece.id) {
+								piecesWithIds++;
+							}
+						}
+					}
+				}
+			}
+		}
+
+		expect(pieceCount).toBeGreaterThan(0);
+		expect(piecesWithIds).toBe(pieceCount);
+	});
+
+	it('hand pieces should have IDs', () => {
+		const handWithIds = gungi.getHandWithIds();
+
+		for (const handPiece of handWithIds) {
+			expect(handPiece.ids).toBeDefined();
+			expect(handPiece.ids!.length).toBe(handPiece.count);
+
+			// Check ID format
+			for (const id of handPiece.ids!) {
+				expect(id).toMatch(/^.+-[wb]-\d+$/);
+				expect(id.includes(handPiece.type)).toBe(true);
+				expect(id.includes(handPiece.color)).toBe(true);
+			}
+		}
+	});
+
+	it('piece IDs should persist after moves', () => {
+		// Get initial piece ID
+		const initialPiece = gungi.getTop('7-1');
+		expect(initialPiece).toBeDefined();
+		expect(initialPiece!.id).toBeDefined();
+		const initialId = initialPiece!.id!;
+
+		// Make a move with this piece
+		gungi.move('兵(7-1-1)(6-1-1)');
+
+		// Check that the same piece now at new location has same ID
+		const movedPiece = gungi.getTop('6-1');
+		expect(movedPiece).toBeDefined();
+		expect(movedPiece!.id).toBe(initialId);
+
+		// Check that old location is empty
+		const oldLocation = gungi.getTop('7-1');
+		expect(oldLocation).toBeUndefined();
+	});
+
+	it('captured pieces should be removed from the game', () => {
+		// Set up a position where we can capture
+		gungi = new Gungi(BEGINNER_POSITION);
+
+		// Make some moves to set up a capture
+		gungi.move('新小(7-5-2)付');
+		gungi.move('兵(3-5-1)(4-5-1)');
+		gungi.move('新槍(7-4-2)付');
+		gungi.move('兵(4-5-1)(5-5-1)');
+
+		// Get the ID of the piece about to be captured
+		const pieceToCapture = gungi.getTop('5-5');
+		expect(pieceToCapture).toBeDefined();
+		expect(pieceToCapture!.id).toBeDefined();
+		const capturedPieceId = pieceToCapture!.id!;
+
+		// Capture the piece
+		gungi.move('小(7-5-2)取(5-5-1)');
+
+		// Check that the captured piece is no longer anywhere in the game
+		const capturedPieceById = gungi.getPieceById(capturedPieceId);
+		expect(capturedPieceById).toBeUndefined();
+
+		// Check that the capturing piece is now at the destination
+		const capturingPiece = gungi.getTop('5-5');
+		expect(capturingPiece).toBeDefined();
+		expect(capturingPiece!.type).toBe('小'); // major general
+	});
+
+	it('arata moves should use existing hand piece IDs', () => {
+		gungi = new Gungi(BEGINNER_POSITION);
+
+		// Get a hand piece ID before arata
+		const initialHand = gungi.getHandWithIds('w');
+		const majorGeneralPiece = initialHand.find((hp) => hp.type === '小');
+		expect(majorGeneralPiece).toBeDefined();
+		expect(majorGeneralPiece!.ids).toBeDefined();
+		const handPieceId = majorGeneralPiece!.ids![0];
+
+		// Make an arata move
+		gungi.move('新小(7-5-2)付');
+
+		// Check that the piece on board has the same ID as the hand piece
+		const placedPiece = gungi.getTop('7-5');
+		expect(placedPiece).toBeDefined();
+		expect(placedPiece!.id).toBe(handPieceId);
+
+		// Check that the hand count decreased and ID was removed
+		const updatedHand = gungi.getHandWithIds('w');
+		const updatedMajorGeneral = updatedHand.find((hp) => hp.type === '小');
+		expect(updatedMajorGeneral!.count).toBe(majorGeneralPiece!.count - 1);
+		expect(updatedMajorGeneral!.ids).not.toContain(handPieceId);
+	});
+
+	it('piece IDs should be unique', () => {
+		const allIds = new Set<string>();
+
+		// Collect all board piece IDs
+		const board = gungi.getBoardWithIds();
+		for (let rank = 0; rank < 9; rank++) {
+			for (let file = 0; file < 9; file++) {
+				const tower = board[rank][file];
+				if (tower && tower[0]) {
+					for (const piece of tower) {
+						if (piece && piece.id) {
+							expect(allIds.has(piece.id)).toBe(false);
+							allIds.add(piece.id);
+						}
+					}
+				}
+			}
+		}
+
+		// Collect all hand piece IDs
+		const hand = gungi.getHandWithIds();
+		for (const handPiece of hand) {
+			if (handPiece.ids) {
+				for (const id of handPiece.ids) {
+					expect(allIds.has(id)).toBe(false);
+					allIds.add(id);
+				}
+			}
+		}
+
+		expect(allIds.size).toBeGreaterThan(0);
+	});
+
+	it('ID format should be correct', () => {
+		const board = gungi.getBoardWithIds();
+
+		for (let rank = 0; rank < 9; rank++) {
+			for (let file = 0; file < 9; file++) {
+				const tower = board[rank][file];
+				if (tower && tower[0]) {
+					for (const piece of tower) {
+						if (piece && piece.id) {
+							// ID should be in format: type-color-number
+							const parts = piece.id.split('-');
+							expect(parts.length).toBe(3);
+							expect(parts[0]).toBe(piece.type);
+							expect(parts[1]).toBe(piece.color);
+							expect(parseInt(parts[2])).toBeGreaterThan(0);
+						}
+					}
+				}
+			}
+		}
+	});
+
+	it('getPieceId method should work correctly', () => {
+		const piece = gungi.getTop('7-1');
+		expect(piece).toBeDefined();
+		expect(piece!.id).toBeDefined();
+
+		const retrievedId = gungi.getPieceId('7-1');
+		expect(retrievedId).toBe(piece!.id);
+
+		const retrievedIdWithTier = gungi.getPieceId('7-1', 1);
+		expect(retrievedIdWithTier).toBe(piece!.id);
+	});
+
+	it('getPieceById method should work correctly', () => {
+		const piece = gungi.getTop('7-1');
+		expect(piece).toBeDefined();
+		expect(piece!.id).toBeDefined();
+
+		const retrievedPiece = gungi.getPieceById(piece!.id!);
+		expect(retrievedPiece).toBeDefined();
+		expect(retrievedPiece!.id).toBe(piece!.id);
+		expect(retrievedPiece!.square).toBe(piece!.square);
+		expect(retrievedPiece!.type).toBe(piece!.type);
+	});
+
+	it('getHandPieceId method should work correctly', () => {
+		gungi = new Gungi(BEGINNER_POSITION);
+
+		const whiteHandPieces = gungi.getHandWithIds('w');
+		const majorGeneral = whiteHandPieces.find((hp) => hp.type === '小');
+		expect(majorGeneral).toBeDefined();
+		expect(majorGeneral!.ids).toBeDefined();
+		expect(majorGeneral!.ids!.length).toBeGreaterThan(0);
+
+		const firstId = gungi.getHandPieceId('小', 'w', 0);
+		expect(firstId).toBe(majorGeneral!.ids![0]);
+
+		const secondId = gungi.getHandPieceId('小', 'w', 1);
+		if (majorGeneral!.ids!.length > 1) {
+			expect(secondId).toBe(majorGeneral!.ids![1]);
+		} else {
+			expect(secondId).toBeUndefined();
+		}
+	});
+
+	it('should handle multiple moves with complex ID tracking', () => {
+		// Test a sequence of moves to ensure IDs remain consistent
+		const initialPiece = gungi.getTop('7-1');
+		expect(initialPiece!.id).toBeDefined();
+		const pieceId = initialPiece!.id!;
+
+		// Move piece multiple times
+		gungi.move('兵(7-1-1)(6-1-1)');
+		let movedPiece = gungi.getTop('6-1');
+		expect(movedPiece!.id).toBe(pieceId);
+
+		gungi.move('侍(3-4-1)(4-4-1)'); // Black move
+		gungi.move('兵(6-1-1)(5-1-1)'); // Move same piece again
+
+		movedPiece = gungi.getTop('5-1');
+		expect(movedPiece!.id).toBe(pieceId);
+
+		// Verify the piece is no longer at previous locations
+		expect(gungi.getTop('7-1')).toBeUndefined();
+		expect(gungi.getTop('6-1')).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Implements unique piece identifiers using `type-color-number` format
that persist across all moves, captures, and state changes.

**Parallel ID Registry**: Chose to maintain existing FEN-based
architecture while adding separate `PieceIdRegistry` class. This
preserves backward compatibility while enabling advanced ID features.

**Snapshot/Restore Pattern**: Since moves regenerate state from FEN
(losing IDs), implemented snapshot-before/restore-after pattern in
`move()` method. Captures ID mappings before FEN reinitialization,
then intelligently restores them accounting for piece movements.

**Individual Hand Tracking**: Extended `HandPiece` with `ids?: string[]`
to track individual pieces within aggregate counts. Enables specific
piece selection for arata moves while maintaining existing count-based API.

**Auto-Assignment**: IDs assigned automatically on game initialization.
All existing code works unchanged, IDs are purely additive enhancement.

- `getPieceId()`, `getPieceById()` - board piece lookup
- `getHandPieceIds()`, `getHandWithIds()` - hand piece access
- `getBoardWithIds()` - complete board state with IDs
- `getHandPieceId()` - specific hand piece selection

Addresses the fundamental challenge of maintaining piece identity
across the library's FEN-based state management system.
